### PR TITLE
Config, ammo deduction and extra checkpoint work

### DIFF
--- a/dlls/glock.cpp
+++ b/dlls/glock.cpp
@@ -19,6 +19,7 @@
 #include "monsters.h"
 #include "weapons.h"
 #include "player.h"
+#include "hardcorestatus.h"
 
 LINK_ENTITY_TO_CLASS(weapon_glock, CGlock);
 LINK_ENTITY_TO_CLASS(weapon_9mmhandgun, CGlock);
@@ -90,6 +91,21 @@ void CGlock::PrimaryAttack()
 
 void CGlock::GlockFire(float flSpread, float flCycleTime, bool fUseAutoAim)
 {
+	// TODO I implemented a Gun Jamming mechanism here but not sure if we want this, people might hate me for it :(
+	/* float rndFloat = RANDOM_FLOAT(0, 1);
+	if (rndFloat < 0.10 && m_iClip > 0)
+	{
+		int rand = RANDOM_FLOAT(1, 5);
+		const std::string gunJamMsg = "Glock Jammed! " + std::to_string(rand) + " seconds.";
+		HardCoreStatus::DisplayMsg(-1, -1, 2.0f, 1, gunJamMsg);
+		PlayEmptySound();
+		m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(rand);
+		m_iClip--;
+		PLAYBACK_EVENT_FULL(0, m_pPlayer->edict(), fUseAutoAim ? m_usFireGlock1 : m_usFireGlock2, 0.0, g_vecZero, g_vecZero, 0, 0, 0, 0, 1, 0);
+		return;
+	}
+	*/
+
 	if (m_iClip <= 0)
 	{
 		//if (m_fFireOnEmpty)

--- a/dlls/hardcorestatus.h
+++ b/dlls/hardcorestatus.h
@@ -21,6 +21,18 @@
 #define DEATH_COUNT_TEXT "Death Count"
 #define WELCOME_MSG "Good Luck!"
 
+#define CKP_DIFF "checkpoint_difficulty"
+#define AMMO_DIFF "ammo_difficulty"
+#define ENEMY_DIFF "enemy_difficulty"
+
+enum Difficulty
+{
+	WALK_IN_THE_PARK,
+	MILD_CHALLENGE,
+	HARD,
+	TRUE_HARDCORE
+};
+
 /*
  * This is a data structure representing the current HardCore Status:
  * - deathCount
@@ -38,35 +50,54 @@ struct HardCoreStatusData
 	bool isDeathCountDisplayed = false;
 	bool isWelcomeMessageDisplayed = false;
 	bool hardcoreStatusLoaded = false;
+	bool hardcoreConfigLoaded = false;
 	bool hasCheckpointItems = false;
+};
+
+struct HardCoreConfig
+{
+	Difficulty checkpointDifficulty;
+	Difficulty ammoDifficulty;
+	Difficulty enemyDifficulty;
 };
 
 class HardCoreStatus
 {
 	public:
+		static void LoadHardCoreStatus();
+		static void LoadHardCoreConfig();
+
+		static void UpdateHardCoreStatusFile();
+
 		static void LoadCheckPoint();
 		static void UpdateCheckPointIfNeeded(const std::string& mapName);
-		static void UpdateHardCoreStatusFile();
-		static void LoadHardCoreStatus();
+		static void GiveCheckpointItemsIfNeeded(CBasePlayer* plr);
+		
 		static void Death();
+
 		static void DisplayDeathCountIfNotDisplayed();
 		static void DisplayWelcomeMessageIfNotDisplayed();
-		static void GiveCheckpointItemsIfNeeded(CBasePlayer* plr);
-
+		
 		/* This will just return the hardcoreStatusLoaded to avoid exposing the whole data */
-		static bool IsHardCoreStatusLoaded()
+		static const bool IsHardCoreStatusLoaded()
 		{
 			return hcData.hardcoreStatusLoaded;
 		}
 
-	private:
-		/*
-		 * Please note that this is STATIC because we only want a single instance of this status throughout the whole game.
-		 */
-		static HardCoreStatusData hcData;
-
-		static std::map<std::string, std::vector<std::string>> checkpointItemMap;
-		static std::vector<std::string> possibleCheckpoints;
+		static const Difficulty GetAmmoDifficulty()
+		{
+			return hcConfig.ammoDifficulty;
+		}
 
 		static void DisplayMsg(const float textXCoord, const float textYCoord, const float displayTime, const int channel, const std::string& textToDisplay);
+
+	private:
+		/*
+		 * Please note that these are STATIC because we only want a single instance of this status throughout the whole game.
+		 */
+		static HardCoreStatusData hcData;
+		static HardCoreConfig hcConfig;
+		static std::map<std::string, std::pair<Difficulty, std::vector<std::string>>> checkpointMap;
+
+		static std::map<std::string, Difficulty> difficultyRepresentation;
 };


### PR DESCRIPTION
Fixes #7

This PR includes:
- New config file for the mod where we can config checkpoint difficulty, ammo difficulty, and enemy difficulty
- Players find less ammo depending on ammo difficulty
- Checkpoint number depends on checkpoint difficulty
- Enemy difficulty is not used yet, might be removed? Not sure, needs discussing
- Added a Glock jamming mechanism but it's unused for now, not sure if this is something we want